### PR TITLE
ci: add Flutter web build to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,23 +11,30 @@ permissions:
   contents: write
 
 jobs:
-  build-android:
-    name: Build Android Release
+  version:
+    name: Extract Version
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true)
-
+    outputs:
+      version: ${{ steps.version.outputs.VERSION }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract version from tag
+      - name: Extract version from pubspec.yaml
         id: version
         run: |
           VERSION=$(grep "^version:" pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+  build-android:
+    name: Build Android Release
+    runs-on: ubuntu-latest
+    needs: version
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -64,10 +71,6 @@ jobs:
       - name: Get dependencies
         run: flutter pub get
 
-      #      - name: Run tests
-      #        run: flutter test
-      #        continue-on-error: true
-
       - name: Run build_runner
         run: dart run build_runner build
 
@@ -77,43 +80,119 @@ jobs:
       - name: Rename APK
         run: |
           mv build/app/outputs/flutter-apk/app-arm64-v8a-ci-release.apk \
-             build/app/outputs/flutter-apk/bill-splitter-v${{ steps.version.outputs.VERSION }}-arm64.apk
+             build/app/outputs/flutter-apk/bill-splitter-v${{ needs.version.outputs.version }}-arm64.apk
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk
+          path: build/app/outputs/flutter-apk/bill-splitter-v${{ needs.version.outputs.version }}-arm64.apk
+          retention-days: 1
+
+      - name: Cleanup keystore
+        if: always()
+        run: |
+          rm -f android/bill-splitter-keystore.jks
+          rm -f android/key.properties
+
+  build-web:
+    name: Build Web Release
+    runs-on: ubuntu-latest
+    needs: version
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Scaffold web platform support
+        run: |
+          if [ ! -d "web" ]; then
+            # Backup lib/ to prevent flutter create from overwriting app code
+            cp -r lib lib_backup
+            flutter create --platforms=web .
+            # Restore original app code
+            rm -rf lib
+            mv lib_backup lib
+          fi
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Run build_runner
+        run: dart run build_runner build
+
+      - name: Build web
+        run: flutter build web --release
+
+      - name: Archive web build
+        run: |
+          cd build/web
+          tar -czf ../../bill-splitter-v${{ needs.version.outputs.version }}-web.tar.gz .
+
+      - name: Upload web artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-build
+          path: bill-splitter-v${{ needs.version.outputs.version }}-web.tar.gz
+          retention-days: 1
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: [version, build-android, build-web]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Android artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-apk
+          path: artifacts/
+
+      - name: Download Web artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: web-build
+          path: artifacts/
 
       - name: Generate changelog
         id: changelog
         run: |
-          # Get commits since last tag
           PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [ -z "$PREV_TAG" ]; then
             CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges)
           else
             CHANGELOG=$(git log ${PREV_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges)
           fi
-          echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
+          echo "CHANGELOG<<CHANGELOG_DELIMITER" >> $GITHUB_OUTPUT
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Create and push tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag v${{ steps.version.outputs.VERSION }}
-          git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git v${{ steps.version.outputs.VERSION }}
+          echo "CHANGELOG_DELIMITER" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.version.outputs.VERSION }}
-          files: build/app/outputs/flutter-apk/bill-splitter-v${{ steps.version.outputs.VERSION }}-arm64.apk
+          tag_name: v${{ needs.version.outputs.version }}
+          files: |
+            artifacts/bill-splitter-v${{ needs.version.outputs.version }}-arm64.apk
+            artifacts/bill-splitter-v${{ needs.version.outputs.version }}-web.tar.gz
           body: |
             ## What's Changed
             ${{ steps.changelog.outputs.CHANGELOG }}
 
           draft: false
-          prerelease: ${{ contains(steps.version.outputs.VERSION, 'beta') || contains(steps.version.outputs.VERSION, 'alpha') }}
+          prerelease: ${{ contains(needs.version.outputs.version, 'beta') || contains(needs.version.outputs.version, 'alpha') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -122,32 +201,18 @@ jobs:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
-          CAPTION=$(printf "Bill Splitter v${{ steps.version.outputs.VERSION }}\n\nRelease Notes: ${{ steps.create_release.outputs.url }}")
+          CAPTION=$(printf "Bill Splitter v${{ needs.version.outputs.version }}\n\nRelease Notes: ${{ steps.create_release.outputs.url }}")
           RESPONSE=$(curl -s -F chat_id="${TELEGRAM_CHAT_ID}" \
-               -F document=@"build/app/outputs/flutter-apk/bill-splitter-v${{ steps.version.outputs.VERSION }}-arm64.apk" \
+               -F document=@"artifacts/bill-splitter-v${{ needs.version.outputs.version }}-arm64.apk" \
                -F caption="$CAPTION" \
                https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendDocument)
 
           echo "$RESPONSE"
 
-          # Check if upload was successful
           if echo "$RESPONSE" | grep -q '"ok":true'; then
             echo "Successfully uploaded to Telegram"
           else
             echo "Failed to upload to Telegram"
             echo "$RESPONSE"
             exit 1
-          fi          
-
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: bill-splitter-v${{ steps.version.outputs.VERSION }}-arm64
-          path: build/app/outputs/flutter-apk/bill-splitter-v${{ steps.version.outputs.VERSION }}-arm64.apk
-          retention-days: 30
-
-      - name: Cleanup keystore
-        if: always()
-        run: |
-          rm -f android/bill-splitter-keystore.jks
-          rm -f android/key.properties
+          fi


### PR DESCRIPTION
Restructure release workflow into parallel jobs (version, build-android,
build-web, release) so Android and web builds run concurrently. The web
build output is archived as a tarball and uploaded to GitHub Releases
alongside the APK.

Additional improvements:
- Upgrade softprops/action-gh-release from v1 to v2
- Let gh-release handle tag creation atomically (removes dangling tag risk)
- Remove unnecessary fetch-depth: 0 from build-android
- Use unique CHANGELOG_DELIMITER to avoid heredoc collision
- Remove no-op `flutter config --enable-web`
- Drop deprecated `--web-renderer canvaskit` flag (canvaskit is default)
- Backup lib/ during `flutter create --platforms=web .` to prevent
  overwriting app code with template scaffold

Note: the web build may fail until platform guards (kIsWeb) are added
for mobile-only dependencies: receive_sharing_intent, quick_actions,
and unconditional dart:io imports.
